### PR TITLE
Add support for Table model

### DIFF
--- a/examples/src/main/kotlin/table/BasicTable.kt
+++ b/examples/src/main/kotlin/table/BasicTable.kt
@@ -1,0 +1,63 @@
+package table
+
+import kscience.plotly.Plotly
+import kscience.plotly.makeFile
+import kscience.plotly.models.HorizontalAlign
+import kscience.plotly.models.Table
+
+/**
+ * - basic table trace with customization.
+ */
+fun main() {
+    val values = listOf(
+        listOf("Salaries", "Office", "Merchandise", "Legal", "<b>TOTAL</b>"),
+        listOf(1200000, 20000, 80000, 2000, 12120000),
+        listOf(1300000, 20000, 70000, 2000, 130902000),
+        listOf(1300000, 20000, 120000, 2000, 131222000),
+        listOf(1400000, 20000, 90000, 2000, 14102000),
+    )
+
+    val labels = listOf(
+            listOf("<b>EXPENSES</b>"), listOf("<b>Q1</b>"), listOf("<b>Q2</b>"), listOf("<b>Q3</b>"), listOf("<b>Q4</b>")
+    )
+
+    val table = Table {
+        columnorder(0, 1, 2, 4, 3)
+        columnwidth(10, 10, 30, 30, 20)
+        header {
+            this.values(labels)
+            align(HorizontalAlign.left, HorizontalAlign.center)
+
+            line {
+                width = 1
+                color("#506784")
+            }
+            fill {
+                color("#119DFF")
+            }
+            font {
+                family = "Arial"
+                size = 12
+                color("white")
+            }
+        }
+        cells {
+            this.values(values)
+            align(HorizontalAlign.left, HorizontalAlign.center)
+            line {
+                width = 1
+                color("#506784")
+            }
+            fill {
+                colors(listOf("#25FEFD", "white"))
+            }
+            font {
+                family = "Arial"
+                size = 11
+                color("#506784")
+            }
+        }
+    }
+
+    Plotly.plot { traces(table) }.makeFile()
+}

--- a/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
+++ b/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
@@ -1,6 +1,8 @@
 package kscience.plotly.models
 
-import hep.dataforge.meta.*
+import hep.dataforge.meta.Scheme
+import hep.dataforge.meta.SchemeSpec
+import hep.dataforge.meta.spec
 import hep.dataforge.names.asName
 import hep.dataforge.values.Value
 import hep.dataforge.values.asValue
@@ -8,11 +10,19 @@ import kscience.plotly.UnsupportedPlotlyAPI
 import kscience.plotly.lazySpec
 import kscience.plotly.numberGreaterThan
 
-
+/**
+ * Scheme to define table cell colors.
+ * */
 public class Fill : Scheme() {
 
+    /**
+     * Sets the cell fill color. It accepts a specific color.
+     * */
     public var color: Color = Color(this, "color".asName())
 
+    /**
+     * Sets the cell fill color. It accepts an array of colors.
+     * */
     public fun colors(array: Iterable<Any>) {
         color.value = array.map { Value.of(it) }.asValue()
     }
@@ -22,16 +32,41 @@ public class Fill : Scheme() {
 
 public class Header : Scheme() {
 
+    /**
+     * Cell values. `values[m][n]` represents the value of the "n"-th point in column "m", therefore
+     * the `values[m]` vector length for all columns must be the same (longer vectors will be truncated).
+     *
+     * Each value must be a finite number or a string.
+     * */
     public var values: TraceValues = TraceValues(this, "values".asName())
 
+    /**
+     * The height of cells.
+     * */
     public var height: Number by numberGreaterThan(1)
 
+    /**
+     * Sets the horizontal alignment of the `text` within the box. Has an effect only if `text` spans
+     * two or more lines (i.e. `text` contains one or more <br> HTML tags) or if an explicit width is set
+     * to override the text width.
+     *
+     * Defaults to `center`.
+     * */
     public var align: TraceValues = TraceValues(this, "align".asName())
 
+    /**
+     * [LayoutLine] type object.
+     * */
     public var line: LayoutLine? by spec(LayoutLine)
 
+    /**
+     * [Fill] type object.
+     * */
     public var fill: Fill? by spec(Fill)
 
+    /**
+     * [Font] type object.
+     * */
     public var font: Font? by spec(Font)
 
     public fun values(array: Iterable<Any>) {
@@ -63,16 +98,41 @@ public class Header : Scheme() {
 
 public class Cells : Scheme() {
 
+    /**
+     * Cell values. `values[m][n]` represents the value of the "n"-th point in column "m", therefore
+     * the `values[m]` vector length for all columns must be the same (longer vectors will be truncated).
+     *
+     * Each value must be a finite number or a string.
+     * */
     public var values: TraceValues = TraceValues(this, "values".asName())
 
+    /**
+     * The height of cells.
+     * */
     public var height: Number by numberGreaterThan(1)
 
+    /**
+     * Sets the horizontal alignment of the `text` within the box. Has an effect only if `text` spans
+     * two or more lines (i.e. `text` contains one or more <br> HTML tags) or if an explicit width is set
+     * to override the text width.
+     *
+     * Defaults to `center`.
+     * */
     public var align: TraceValues = TraceValues(this, "align".asName())
 
+    /**
+     * [LayoutLine] type object.
+     * */
     public var line: LayoutLine? by spec(LayoutLine)
 
+    /**
+     * [Fill] type object.
+     * */
     public var fill: Fill? by spec(Fill)
 
+    /**
+     * [Font] type object.
+     * */
     public var font: Font? by spec(Font)
 
     public fun values(array: Iterable<Any>) {
@@ -106,20 +166,46 @@ public class Cells : Scheme() {
     public companion object : SchemeSpec<Cells>(::Cells)
 }
 
+/**
+ * Table view for detailed data viewing. The data are arranged in a grid of rows and columns. Most styling can
+ * be specified for columns, rows or individual cells. Table is using a column-major order, ie. the
+ * grid is represented as a vector of column vectors.
+ * */
 @UnsupportedPlotlyAPI
 public class Table : Trace() {
     init {
         type = TraceType.table
     }
 
+    /**
+     * Assigns id labels to each datum. These ids for object constancy of data points during animation.
+     *
+     * Should be an array of strings, not numbers or any other type.
+     * */
     public var ids: TraceValues = TraceValues(this, "ids".asName())
 
+    /**
+     * Specifies the rendered order of the data columns; for example, a value `2` at position `0`
+     * means that column index `0` in the data will be rendered as the third column,
+     * as columns have an index base of zero.
+     * */
     public var columnorder: TraceValues = TraceValues(this, "columnorder".asName())
 
+
+    /**
+     * The width of columns expressed as a ratio. Columns fill the available width
+     * in proportion of their specified column widths.
+     * */
     public var columnwidth: TraceValues = TraceValues(this, "columnwidth".asName())
 
+    /**
+     * [Header] type object. Used to define the header row.
+     * */
     public var header: Header by lazySpec(Header)
 
+    /**
+     * [Cells] type object. Used to define rows containing data.
+     * */
     public var cells: Cells by lazySpec(Cells)
 
     public fun header(block: Header.() -> Unit) {

--- a/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
+++ b/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
@@ -6,7 +6,6 @@ import hep.dataforge.meta.spec
 import hep.dataforge.names.asName
 import hep.dataforge.values.Value
 import hep.dataforge.values.asValue
-import kscience.plotly.UnsupportedPlotlyAPI
 import kscience.plotly.lazySpec
 import kscience.plotly.numberGreaterThan
 
@@ -171,7 +170,6 @@ public class Cells : Scheme() {
  * be specified for columns, rows or individual cells. Table is using a column-major order, ie. the
  * grid is represented as a vector of column vectors.
  * */
-@UnsupportedPlotlyAPI
 public class Table : Trace() {
     init {
         type = TraceType.table

--- a/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
+++ b/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
@@ -8,46 +8,6 @@ import kscience.plotly.UnsupportedPlotlyAPI
 import kscience.plotly.lazySpec
 import kscience.plotly.numberGreaterThan
 
-public class Hoverlabel : Scheme() {
-
-    public var bgcolor: Color = Color(this, "bgcolor".asName())
-
-    public var bordercolor: Color = Color(this, "bordercolor".asName())
-
-    public var font: Font? by spec(Font)
-
-    public var align: TraceValues = TraceValues(this, "align".asName())
-
-    public var namelength: Number by numberGreaterThan(-1)
-
-    public var namelengths: List<Number> by numberList(-1, key = "namelength".asName())
-
-    public fun bgcolors(array: Iterable<Any>) {
-        bgcolor.value = array.map { Value.of(it) }.asValue()
-    }
-
-    public fun bordercolors(array: Iterable<Any>) {
-        bordercolor.value = array.map { Value.of(it) }.asValue()
-    }
-
-    public fun font(block: Font.() -> Unit) {
-        font = Font(block)
-    }
-
-    public fun align(align: HorizontalAlign) {
-        align(listOf(align))
-    }
-
-    public fun align(alignments: List<HorizontalAlign>) {
-        this.align.set(alignments)
-    }
-
-    public fun align(vararg alignments: HorizontalAlign) {
-        this.align.set(alignments.toList())
-    }
-
-    public companion object : SchemeSpec<Hoverlabel>(::Hoverlabel)
-}
 
 public class Fill : Scheme() {
 
@@ -162,18 +122,12 @@ public class Table : Trace() {
 
     public var cells: Cells by lazySpec(Cells)
 
-    public var hoverlabel: Hoverlabel? by spec(Hoverlabel)
-
     public fun header(block: Header.() -> Unit) {
         header = Header(block)
     }
 
     public fun cells(block: Cells.() -> Unit) {
         cells = Cells(block)
-    }
-
-    public fun hoverlabel(block: Hoverlabel.() -> Unit) {
-        hoverlabel = Hoverlabel(block)
     }
 
     public companion object : SchemeSpec<Table>(::Table)

--- a/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
+++ b/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
@@ -169,6 +169,8 @@ public class Cells : Scheme() {
  * Table view for detailed data viewing. The data are arranged in a grid of rows and columns. Most styling can
  * be specified for columns, rows or individual cells. Table is using a column-major order, ie. the
  * grid is represented as a vector of column vectors.
+ *
+ * For docs, see: [Plotly JS Table Reference](https://plotly.com/javascript/reference/table/#table)
  * */
 public class Table : Trace() {
     init {

--- a/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
+++ b/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Table.kt
@@ -1,0 +1,180 @@
+package kscience.plotly.models
+
+import hep.dataforge.meta.*
+import hep.dataforge.names.asName
+import hep.dataforge.values.Value
+import hep.dataforge.values.asValue
+import kscience.plotly.UnsupportedPlotlyAPI
+import kscience.plotly.lazySpec
+import kscience.plotly.numberGreaterThan
+
+public class Hoverlabel : Scheme() {
+
+    public var bgcolor: Color = Color(this, "bgcolor".asName())
+
+    public var bordercolor: Color = Color(this, "bordercolor".asName())
+
+    public var font: Font? by spec(Font)
+
+    public var align: TraceValues = TraceValues(this, "align".asName())
+
+    public var namelength: Number by numberGreaterThan(-1)
+
+    public var namelengths: List<Number> by numberList(-1, key = "namelength".asName())
+
+    public fun bgcolors(array: Iterable<Any>) {
+        bgcolor.value = array.map { Value.of(it) }.asValue()
+    }
+
+    public fun bordercolors(array: Iterable<Any>) {
+        bordercolor.value = array.map { Value.of(it) }.asValue()
+    }
+
+    public fun font(block: Font.() -> Unit) {
+        font = Font(block)
+    }
+
+    public fun align(align: HorizontalAlign) {
+        align(listOf(align))
+    }
+
+    public fun align(alignments: List<HorizontalAlign>) {
+        this.align.set(alignments)
+    }
+
+    public fun align(vararg alignments: HorizontalAlign) {
+        this.align.set(alignments.toList())
+    }
+
+    public companion object : SchemeSpec<Hoverlabel>(::Hoverlabel)
+}
+
+public class Fill : Scheme() {
+
+    public var color: Color = Color(this, "color".asName())
+
+    public fun colors(array: Iterable<Any>) {
+        color.value = array.map { Value.of(it) }.asValue()
+    }
+
+    public companion object : SchemeSpec<Fill>(::Fill)
+}
+
+public class Header : Scheme() {
+
+    public var values: TraceValues = TraceValues(this, "values".asName())
+
+    public var height: Number by numberGreaterThan(1)
+
+    public var align: TraceValues = TraceValues(this, "align".asName())
+
+    public var line: LayoutLine? by spec(LayoutLine)
+
+    public var fill: Fill? by spec(Fill)
+
+    public var font: Font? by spec(Font)
+
+    public fun values(array: Iterable<Any>) {
+        values.set(array)
+    }
+
+    public fun align(align: HorizontalAlign) {
+        align(listOf(align))
+    }
+
+    public fun align(alignments: List<HorizontalAlign>) {
+        this.align.set(alignments)
+    }
+
+    public fun align(vararg alignments: HorizontalAlign) {
+        this.align.set(alignments.toList())
+    }
+
+    public fun fill(block: Fill.() -> Unit) {
+        fill = Fill(block)
+    }
+
+    public fun font(block: Font.() -> Unit) {
+        font = Font(block)
+    }
+
+    public companion object : SchemeSpec<Header>(::Header)
+}
+
+public class Cells : Scheme() {
+
+    public var values: TraceValues = TraceValues(this, "values".asName())
+
+    public var height: Number by numberGreaterThan(1)
+
+    public var align: TraceValues = TraceValues(this, "align".asName())
+
+    public var line: LayoutLine? by spec(LayoutLine)
+
+    public var fill: Fill? by spec(Fill)
+
+    public var font: Font? by spec(Font)
+
+    public fun values(array: Iterable<Any>) {
+        values.set(array)
+    }
+
+    public fun align(align: HorizontalAlign) {
+        align(listOf(align))
+    }
+
+    public fun align(alignments: List<HorizontalAlign>) {
+        this.align.set(alignments)
+    }
+
+    public fun align(vararg alignments: HorizontalAlign) {
+        this.align.set(alignments.toList())
+    }
+
+    public fun fill(block: Fill.() -> Unit) {
+        fill = Fill(block)
+    }
+
+    public fun font(block: Font.() -> Unit) {
+        font = Font(block)
+    }
+
+    public fun line(block: LayoutLine.() -> Unit) {
+        line = LayoutLine(block)
+    }
+
+    public companion object : SchemeSpec<Cells>(::Cells)
+}
+
+@UnsupportedPlotlyAPI
+public class Table : Trace() {
+    init {
+        type = TraceType.table
+    }
+
+    public var ids: TraceValues = TraceValues(this, "ids".asName())
+
+    public var columnorder: TraceValues = TraceValues(this, "columnorder".asName())
+
+    public var columnwidth: TraceValues = TraceValues(this, "columnwidth".asName())
+
+    public var header: Header by lazySpec(Header)
+
+    public var cells: Cells by lazySpec(Cells)
+
+    public var hoverlabel: Hoverlabel? by spec(Hoverlabel)
+
+    public fun header(block: Header.() -> Unit) {
+        header = Header(block)
+    }
+
+    public fun cells(block: Cells.() -> Unit) {
+        cells = Cells(block)
+    }
+
+    public fun hoverlabel(block: Hoverlabel.() -> Unit) {
+        hoverlabel = Hoverlabel(block)
+    }
+
+    public companion object : SchemeSpec<Table>(::Table)
+}

--- a/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Trace.kt
+++ b/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Trace.kt
@@ -21,7 +21,6 @@ public enum class TraceType {
     heatmapgl,
     contour,
 
-    @UnsupportedPlotlyAPI
     table,
 
     @UnsupportedPlotlyAPI

--- a/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Trace.kt
+++ b/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Trace.kt
@@ -626,6 +626,47 @@ public class Domain : Scheme() {
     public companion object : SchemeSpec<Domain>(::Domain)
 }
 
+public class Hoverlabel : Scheme() {
+
+    public var bgcolor: Color = Color(this, "bgcolor".asName())
+
+    public var bordercolor: Color = Color(this, "bordercolor".asName())
+
+    public var font: Font? by spec(Font)
+
+    public var align: TraceValues = TraceValues(this, "align".asName())
+
+    public var namelength: Number by numberGreaterThan(-1)
+
+    public var namelengths: List<Number> by numberList(-1, key = "namelength".asName())
+
+    public fun bgcolors(array: Iterable<Any>) {
+        bgcolor.value = array.map { Value.of(it) }.asValue()
+    }
+
+    public fun bordercolors(array: Iterable<Any>) {
+        bordercolor.value = array.map { Value.of(it) }.asValue()
+    }
+
+    public fun font(block: Font.() -> Unit) {
+        font = Font(block)
+    }
+
+    public fun align(align: HorizontalAlign) {
+        align(listOf(align))
+    }
+
+    public fun align(alignments: List<HorizontalAlign>) {
+        this.align.set(alignments)
+    }
+
+    public fun align(vararg alignments: HorizontalAlign) {
+        this.align.set(alignments.toList())
+    }
+
+    public companion object : SchemeSpec<Hoverlabel>(::Hoverlabel)
+}
+
 /**
  * A base class for Plotly traces
  */
@@ -869,6 +910,8 @@ public open class Trace : Scheme() {
 
     public var domain: Domain by spec(Domain)
 
+    public var hoverlabel: Hoverlabel? by spec(Hoverlabel)
+
     public fun values(array: Iterable<Any>) {
         values = array.map { Value.of(it) }
     }
@@ -903,6 +946,10 @@ public open class Trace : Scheme() {
 
     public fun domain(block: Domain.() -> Unit) {
         domain = Domain(block)
+    }
+
+    public fun hoverlabel(block: Hoverlabel.() -> Unit) {
+        hoverlabel = Hoverlabel(block)
     }
 
     public companion object : SchemeSpec<Trace>(::Trace) {

--- a/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Trace.kt
+++ b/plotlykt-core/src/commonMain/kotlin/kscience/plotly/models/Trace.kt
@@ -628,16 +628,40 @@ public class Domain : Scheme() {
 
 public class Hoverlabel : Scheme() {
 
+    /**
+     * Sets the background color of the hover labels for this trace.
+     * */
     public var bgcolor: Color = Color(this, "bgcolor".asName())
 
+    /**
+     * Sets the border color of the hover labels for this trace.
+     * */
     public var bordercolor: Color = Color(this, "bordercolor".asName())
 
+    /**
+     * Sets the font used in hover labels.
+     * */
     public var font: Font? by spec(Font)
 
+    /**
+     * Sets the horizontal alignment of the text content within hover label box. Has an effect
+     * only if the hover label text spans more two or more lines.
+     *
+     * Defaults to `'auto'`.
+     * */
     public var align: TraceValues = TraceValues(this, "align".asName())
 
+    /**
+     * Sets the default length (in number of characters) of the trace name in the hover labels for all traces.
+     * -1 shows the whole name regardless of length. 0-3 shows the first 0-3 characters, and an integer >3 will
+     * show the whole name if it is less than that many characters, but if it is longer, will truncate to
+     * `namelength - 3` characters and add an ellipsis.
+     * */
     public var namelength: Number by numberGreaterThan(-1)
 
+    /**
+     * Complementary property to [namelength] to allow passing a list of lengths.
+     * */
     public var namelengths: List<Number> by numberList(-1, key = "namelength".asName())
 
     public fun bgcolors(array: Iterable<Any>) {


### PR DESCRIPTION
This PR adds support for plotly `Table` model/widget. It includes most of the available table properties.

Thanks for making this, library works great.