### PR TITLE
Fix PlotGrid grid row ordering

### DIFF
--- a/plotlykt-core/src/jvmMain/kotlin/kscience/plotly/PlotGrid.kt
+++ b/plotlykt-core/src/jvmMain/kotlin/kscience/plotly/PlotGrid.kt
@@ -8,9 +8,12 @@ class PlotGrid {
 
     private val cells = HashMap<String, PlotCell>()
 
+    /**
+     * @return Columns in ascending order, grouped by rows in ascending order.
+     * */
     val grid
-        get() = cells.values.groupBy { it.row }.values.map {
-            it.sortedBy { plot -> plot.col }
+        get() = cells.values.groupBy { it.row }.toSortedMap().values.map {
+            it.sortedBy { cell -> cell.col }
         }.toList()
 
     operator fun get(id: String): PlotCell? = cells[id]

--- a/plotlykt-core/src/jvmMain/kotlin/kscience/plotly/PlotGrid.kt
+++ b/plotlykt-core/src/jvmMain/kotlin/kscience/plotly/PlotGrid.kt
@@ -3,25 +3,25 @@ package  kscience.plotly
 import kotlinx.html.div
 
 @UnstablePlotlyAPI
-class PlotGrid {
-    data class PlotCell(val id: String, val plot: Plot, val row: Int, val col: Int, val width: Int = 1)
+public class PlotGrid {
+    public data class PlotCell(val id: String, val plot: Plot, val row: Int, val col: Int, val width: Int = 1)
 
     private val cells = HashMap<String, PlotCell>()
 
     /**
      * @return Columns in ascending order, grouped by rows in ascending order.
      * */
-    val grid
+    public val grid: List<List<PlotCell>>
         get() = cells.values.groupBy { it.row }.toSortedMap().values.map {
             it.sortedBy { cell -> cell.col }
         }.toList()
 
-    operator fun get(id: String): PlotCell? = cells[id]
+    public operator fun get(id: String): PlotCell? = cells[id]
 
     private var currentRow = 0
     private var currentCol = 0
 
-    fun plot(
+    public fun plot(
         plot: Plot,
         id: String = plot.toString(),
         width: Int = 6,
@@ -42,7 +42,7 @@ class PlotGrid {
         return plot
     }
 
-    fun plot(
+    public fun plot(
         row: Int? = null,
         col: Int? = null,
         id: String? = null,
@@ -55,7 +55,7 @@ class PlotGrid {
 }
 
 @UnstablePlotlyAPI
-fun Plotly.grid(block: PlotGrid.() -> Unit): PlotlyPage {
+public fun Plotly.grid(block: PlotGrid.() -> Unit): PlotlyPage {
     val grid = PlotGrid().apply(block)
     return page(cdnBootstrap, cdnPlotlyHeader) { container ->
         div("col") {


### PR DESCRIPTION
Previous implementation did not sort the map by keys, occasionally causing random row order. New implementation sorts the intermediary map by its keys (rows) in ascending order to have consistent ordering.